### PR TITLE
Added new ruby script to check the repo status

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://www.rubygems.org'
 
 gem 'rake'
+gem 'github_api'

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ If you would like to update any of the jobs, you need to use the [update jobs][u
 job. Clone down the repo, and if it changes at all it'll update the corresponding
 jobs.
 
+We have added a new test that is being rolled out and that is a measure of the health of the cookbook project.  This measures the age of Issues and PRs.  If any have not been updated for 8 days then this will automatically fail the build.  The URL for each of the violations will be displayed in the console output.
+
 ## The Jenkins Job YAMLs for the Cookbooks
 | Cookbook  | Build Status |
 | ------------- | ------------- |

--- a/bin/repohealth.rb
+++ b/bin/repohealth.rb
@@ -1,0 +1,132 @@
+require "github_api"
+require "optparse"
+require "ostruct"
+require "yaml"
+
+# Configure the command line options
+options = {}
+options[:age] = 8
+
+opt_parser = OptionParser.new do |opts|
+  opts.banner = "Usage: repoheartbeat.rb [options]"
+
+  opts.separator ""
+  opts.separator "Specific Options"
+
+  opts.on("-a", "--age AGE", "Acceptable age of issue") do |a|
+    options[:age] = a.to_i
+  end
+
+  opts.on("-o", "--owner OWNER", "Repository Owner") do |o|
+    options[:owner] = o
+  end
+
+  opts.on("-r", "--repo REPO", "Repository Name") do |r|
+    options[:repo] = r
+  end
+
+  opts.on("-t", "--token TOKEN", "oAuth Token") do |t|
+    options[:token] = t
+  end
+
+end
+
+opt_parser.parse!
+
+def issueAge(start_date, end_date)
+
+  end_date = Time.parse end_date
+
+  seconds_diff = (start_date - end_date).to_i.abs 
+
+  return seconds_diff / 86400
+end
+
+# Read the configuration file in the user home directory for the client_id and client_secret
+# They can be passed on the command line but it is not recommended
+if options[:token].nil?
+
+  # Determine if the configuration file for the credentials exists
+  config_file = File.join(Dir.home, ".repohealth")
+
+  if File.exists?(config_file)
+    config = YAML.load_file(config_file)
+  else 
+    puts format("ERROR: Configuration file cannot be located: %s", config_file)
+    exit 2
+  end
+
+  oauth = config["oauth"]
+
+else
+  oauth = {
+    "token" => options[:token]
+  }
+end
+
+# Final check for the ouath details
+if oauth["token"].nil?
+  puts "ERROR:  A token must be specified for GitHub oAuth authentication"
+  exit 3
+end
+
+github = Github.new oauth_token: options[:token] 
+
+items = github.issues.list user: options[:owner], repo: options[:repo], auto_pagination: true
+
+# create counters for issues and prs
+issues = 0
+prs = 0
+
+# Determine the date time now so that a comparison can be made to the update time of the issues
+dtnow = Time.now.utc
+
+# set counter for violations
+violations = {
+  :pr => {
+    :count => 0,
+    :urls => []
+  },
+  :issues => {
+    :count => 0,
+    :urls => []
+  }
+}
+
+# Iterate around the issues to get the type and the age
+items.each do |item|
+
+  if item.key?('pull_request')
+    if (issueAge(dtnow, item.updated_at) > options[:age])
+      violations[:pr][:count] += 1 
+      violations[:pr][:urls] << item.url
+    end
+    prs += 1
+  else
+    if (issueAge(dtnow, item.updated_at) > options[:age])
+      violations[:issues][:count] += 1 
+      violations[:issues][:urls] << item.url
+    end
+    issues += 1
+  end
+end
+
+# Determine what the violations are
+exitcode = 0
+if violations[:pr][:count] > 0
+  puts format("ERROR: %s Pull requests have not been looked at for %s or more days", violations[:pr][:count], options[:age])
+  violations[:pr][:urls].each do |url|
+    puts url
+  end
+  exitcode = 1
+end
+
+if violations[:issues][:count] > 0
+  puts format("ERROR: %s issues have not been looked at for %s or more days", violations[:issues][:count], options[:age])
+  violations[:issues][:urls].each do |url|
+    puts url
+  end
+  exitcode = 1
+end 
+
+exit exitcode


### PR DESCRIPTION
This uses the GitHub API to check the the issues age and if they have gone stale or not.

A token is required on the machine in `~/.repohealth` with the following information:

```
oauth:
   token: 122455667df
```

With this the script is able to then communicate with GitHub for the named repo and determine the age of the issues.  If any are found to be older than 8 days the build will fail.

The 8 days is configurable on a per build basis.

In addition to stating how many issues and PRs are in violation a list of URLs for each of them is provided.
